### PR TITLE
Fix contribution link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/process_lock.
+Bug reports and pull requests are welcome on GitHub at https://github.com/forwardfinancing/process_lock.


### PR DESCRIPTION
Just a small edit. Fix link to correct repo URL in the contribution part of the Readme file.